### PR TITLE
Don't depend on a connection to run the tests

### DIFF
--- a/osdb.gemspec
+++ b/osdb.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'webmock', '~> 1.8.11'
+  s.add_development_dependency 'vcr', '~> 2.3.0'
 end

--- a/spec/fixtures/http/check_movie_hash.yml
+++ b/spec/fixtures/http/check_movie_hash.yml
@@ -1,0 +1,141 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.opensubtitles.org/xml-rpc
+    body:
+      encoding: US-ASCII
+      string: ! '<?xml version="1.0" ?><methodCall><methodName>LogIn</methodName><params><param><value><string></string></value></param><param><value><string></string></value></param><param><value><string>eng</string></value></param><param><value><string>OS
+        Test User Agent</string></value></param></params></methodCall>
+
+'
+    headers:
+      User-Agent:
+      - XMLRPC::Client (Ruby 1.9.3)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '304'
+      Connection:
+      - keep-alive
+      Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '504'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sat, 03 Nov 2012 13:58:54 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Cache-Backend:
+      - www
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<methodResponse>\n<params>\n
+        <param>\n  <value>\n   <struct>\n    <member>\n     <name>token</name>\n     <value>\n
+        \     <string>0ij4vtkcg3lca6023sofhifom7</string>\n     </value>\n    </member>\n
+        \   <member>\n     <name>status</name>\n     <value>\n      <string>200 OK</string>\n
+        \    </value>\n    </member>\n    <member>\n     <name>seconds</name>\n     <value>\n
+        \     <double>0.009</double>\n     </value>\n    </member>\n   </struct>\n
+        \ </value>\n </param>\n</params>\n</methodResponse>\n"
+    http_version: 
+  recorded_at: Sat, 03 Nov 2012 13:58:58 GMT
+- request:
+    method: post
+    uri: http://api.opensubtitles.org/xml-rpc
+    body:
+      encoding: US-ASCII
+      string: ! '<?xml version="1.0" ?><methodCall><methodName>CheckMovieHash</methodName><params><param><value><string>0ij4vtkcg3lca6023sofhifom7</string></value></param><param><value><array><data><value><string>37d0c7d0cfcbe280</string></value></data></array></value></param></params></methodCall>
+
+'
+    headers:
+      User-Agent:
+      - XMLRPC::Client (Ruby 1.9.3)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '283'
+      Connection:
+      - keep-alive
+      Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Set-Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7; path=/
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1800'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sat, 03 Nov 2012 13:58:55 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Cache-Backend:
+      - www
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<methodResponse>\n<params>\n
+        <param>\n  <value>\n   <struct>\n    <member>\n     <name>status</name>\n
+        \    <value>\n      <string>200 OK</string>\n     </value>\n    </member>\n
+        \   <member>\n     <name>data</name>\n     <value>\n      <struct>\n       <member>\n
+        \       <name>37d0c7d0cfcbe280</name>\n        <value>\n         <struct>\n
+        \         <member>\n           <name>MovieHash</name>\n           <value>\n
+        \           <string>37d0c7d0cfcbe280</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbID</name>\n           <value>\n
+        \           <string>0117500</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieName</name>\n           <value>\n
+        \           <string>The Rock</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieKind</name>\n           <value>\n
+        \           <string>movie</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesSeason</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesEpisode</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \        </struct>\n        </value>\n       </member>\n      </struct>\n
+        \    </value>\n    </member>\n    <member>\n     <name>not_processed</name>\n
+        \    <value>\n      <array>\n       <data/>\n      </array>\n     </value>\n
+        \   </member>\n    <member>\n     <name>seconds</name>\n     <value>\n      <double>0.031</double>\n
+        \    </value>\n    </member>\n   </struct>\n  </value>\n </param>\n</params>\n</methodResponse>\n"
+    http_version: 
+  recorded_at: Sat, 03 Nov 2012 13:58:58 GMT
+recorded_with: VCR 2.3.0

--- a/spec/fixtures/http/get_imdb_movie_details.yml
+++ b/spec/fixtures/http/get_imdb_movie_details.yml
@@ -1,0 +1,143 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.opensubtitles.org/xml-rpc
+    body:
+      encoding: US-ASCII
+      string: ! '<?xml version="1.0" ?><methodCall><methodName>GetIMDBMovieDetails</methodName><params><param><value><string>0ij4vtkcg3lca6023sofhifom7</string></value></param><param><value><string>0176415</string></value></param></params></methodCall>
+
+'
+    headers:
+      User-Agent:
+      - XMLRPC::Client (Ruby 1.9.3)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '236'
+      Connection:
+      - keep-alive
+      Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Set-Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7; path=/
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '6866'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sat, 03 Nov 2012 13:58:58 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Cache-Backend:
+      - www
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<methodResponse>\n<params>\n
+        <param>\n  <value>\n   <struct>\n    <member>\n     <name>status</name>\n
+        \    <value>\n      <string>200 OK</string>\n     </value>\n    </member>\n
+        \   <member>\n     <name>data</name>\n     <value>\n      <struct>\n       <member>\n
+        \       <name>cast</name>\n        <value>\n         <struct>\n          <member>\n
+        \          <name>_0273178</name>\n           <value>\n            <string>Fernando
+        Fern&#195;&#161;n G&#195;&#179;mez</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>_0022264</name>\n           <value>\n
+        \           <string>Rafael Alonso</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>_0347201</name>\n           <value>\n
+        \           <string>Cayetana Guill&#195;&#169;n Cuervo</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>_0328020</name>\n
+        \          <value>\n            <string>Agust&#195;&#173;n Gonz&#195;&#161;lez</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>_0190285</name>\n
+        \          <value>\n            <string>Cristina Cruz</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>_0747510</name>\n
+        \          <value>\n            <string>Alicia Rozas</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>_0347218</name>\n
+        \          <value>\n            <string>Fernando Guill&#195;&#169;n</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>_0685037</name>\n
+        \          <value>\n            <string>Francisco Piquer</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>_0557456</name>\n
+        \          <value>\n            <string>Mar&#195;&#173;a Massip</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>_0137138</name>\n
+        \          <value>\n            <string>Jos&#195;&#169; Caride</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>_0019330</name>\n
+        \          <value>\n            <string>Francisco Algora</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>_0169358</name>\n
+        \          <value>\n            <string>Emma Cohen</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>_0130703</name>\n
+        \          <value>\n            <string>Juan Calot</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>_0350881</name>\n
+        \          <value>\n            <string>Concha G&#195;&#179;mez Conde</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>_0736047</name>\n
+        \          <value>\n            <string>Nuria Rodr&#195;&#173;guez</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \      </member>\n       <member>\n        <name>writers</name>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>_0305054</name>\n
+        \          <value>\n            <string>Jos&#195;&#169; Luis Garci</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>_0701918</name>\n
+        \          <value>\n            <string>Benito P&#195;&#169;rez Gald&#195;&#179;s</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \      </member>\n       <member>\n        <name>rating</name>\n        <value>\n
+        \        <string>7.4</string>\n        </value>\n       </member>\n       <member>\n
+        \       <name>kind</name>\n        <value>\n         <string>movie</string>\n
+        \       </value>\n       </member>\n       <member>\n        <name>cover</name>\n
+        \       <value>\n         <string>http://ia.media-imdb.com/images/M/MV5BMTkwNzIxMTgzMF5BMl5BanBnXkFtZTYwOTkyMTA5._V1._SY317_CR5,0,214,317_.jpg</string>\n
+        \       </value>\n       </member>\n       <member>\n        <name>awards</name>\n
+        \       <value>\n         <array>\n          <data>\n           <value>\n
+        \           <string>Nominated for Oscar. Another 9 wins &#38; 17 nominations</string>\n
+        \          </value>\n          </data>\n         </array>\n        </value>\n
+        \      </member>\n       <member>\n        <name>genres</name>\n        <value>\n
+        \        <array>\n          <data>\n           <value>\n            <string>Drama</string>\n
+        \          </value>\n          </data>\n         </array>\n        </value>\n
+        \      </member>\n       <member>\n        <name>id</name>\n        <value>\n
+        \        <string>0176415</string>\n        </value>\n       </member>\n       <member>\n
+        \       <name>votes</name>\n        <value>\n         <string>1056</string>\n
+        \       </value>\n       </member>\n       <member>\n        <name>country</name>\n
+        \       <value>\n         <array>\n          <data>\n           <value>\n
+        \           <string>Spain</string>\n           </value>\n          </data>\n
+        \        </array>\n        </value>\n       </member>\n       <member>\n        <name>language</name>\n
+        \       <value>\n         <array>\n          <data>\n           <value>\n
+        \           <string>Spanish</string>\n           </value>\n          </data>\n
+        \        </array>\n        </value>\n       </member>\n       <member>\n        <name>directors</name>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>_0305054</name>\n
+        \          <value>\n            <string>Jos&#195;&#169; Luis Garci</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \      </member>\n       <member>\n        <name>duration</name>\n        <value>\n
+        \        <string>151 min</string>\n        </value>\n       </member>\n       <member>\n
+        \       <name>plot</name>\n        <value>\n         <string>After his son
+        dies, an elderly man comes back to Spain from the US and hopes to find out
+        which of his granddaughters is true, and which one is bastard.</string>\n
+        \       </value>\n       </member>\n       <member>\n        <name>title</name>\n
+        \       <value>\n         <string>El abuelo</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>aka</name>\n        <value>\n         <array>\n
+        \         <data>\n           <value>\n            <string>The Grandfather
+        (Canada (English title) / International (English title) / USA)</string>\n
+        \          </value>\n           <value>\n            <string>A nagyapa (Hungary
+        (imdb display title))</string>\n           </value>\n           <value>\n
+        \           <string>Dziadek (Poland)</string>\n           </value>\n          </data>\n
+        \        </array>\n        </value>\n       </member>\n       <member>\n        <name>year</name>\n
+        \       <value>\n         <string>1998</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>request_from</name>\n        <value>\n         <string>cache_redis</string>\n
+        \       </value>\n       </member>\n      </struct>\n     </value>\n    </member>\n
+        \   <member>\n     <name>seconds</name>\n     <value>\n      <double>0.009</double>\n
+        \    </value>\n    </member>\n   </struct>\n  </value>\n </param>\n</params>\n</methodResponse>\n"
+    http_version: 
+  recorded_at: Sat, 03 Nov 2012 13:59:02 GMT
+recorded_with: VCR 2.3.0

--- a/spec/fixtures/http/log_in.yml
+++ b/spec/fixtures/http/log_in.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.opensubtitles.org/xml-rpc
+    body:
+      encoding: US-ASCII
+      string: ! '<?xml version="1.0" ?><methodCall><methodName>LogIn</methodName><params><param><value><string></string></value></param><param><value><string></string></value></param><param><value><string>eng</string></value></param><param><value><string>OS
+        Test User Agent</string></value></param></params></methodCall>
+
+'
+    headers:
+      User-Agent:
+      - XMLRPC::Client (Ruby 1.9.3)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '304'
+      Connection:
+      - keep-alive
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Set-Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7; path=/
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '504'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sat, 03 Nov 2012 13:58:53 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Cache-Backend:
+      - www
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<methodResponse>\n<params>\n
+        <param>\n  <value>\n   <struct>\n    <member>\n     <name>token</name>\n     <value>\n
+        \     <string>0ij4vtkcg3lca6023sofhifom7</string>\n     </value>\n    </member>\n
+        \   <member>\n     <name>status</name>\n     <value>\n      <string>200 OK</string>\n
+        \    </value>\n    </member>\n    <member>\n     <name>seconds</name>\n     <value>\n
+        \     <double>0.014</double>\n     </value>\n    </member>\n   </struct>\n
+        \ </value>\n </param>\n</params>\n</methodResponse>\n"
+    http_version: 
+  recorded_at: Sat, 03 Nov 2012 13:58:57 GMT
+recorded_with: VCR 2.3.0

--- a/spec/fixtures/http/log_out.yml
+++ b/spec/fixtures/http/log_out.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.opensubtitles.org/xml-rpc
+    body:
+      encoding: US-ASCII
+      string: ! '<?xml version="1.0" ?><methodCall><methodName>LogOut</methodName><params><param><value><string>0ij4vtkcg3lca6023sofhifom7</string></value></param></params></methodCall>
+
+'
+    headers:
+      User-Agent:
+      - XMLRPC::Client (Ruby 1.9.3)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '169'
+      Connection:
+      - keep-alive
+      Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '326'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sat, 03 Nov 2012 13:58:54 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Cache-Backend:
+      - www
+    body:
+      encoding: US-ASCII
+      string: ! "<methodResponse>\n <params>\n  <param>\n   <value>\n    <struct>\n
+        \    <member>\n      <name>status</name>\n      <value><string>200 OK</string></value>\n
+        \    </member>\n     <member>\n      <name>seconds</name>\n      <value><double>0.001</double></value>\n
+        \    </member>\n    </struct>\n   </value>\n  </param>\n </params>\n</methodResponse>"
+    http_version: 
+  recorded_at: Sat, 03 Nov 2012 13:58:57 GMT
+recorded_with: VCR 2.3.0

--- a/spec/fixtures/http/search_imdb.yml
+++ b/spec/fixtures/http/search_imdb.yml
@@ -1,0 +1,271 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.opensubtitles.org/xml-rpc
+    body:
+      encoding: US-ASCII
+      string: ! '<?xml version="1.0" ?><methodCall><methodName>SearchMoviesOnIMDB</methodName><params><param><value><string>0ij4vtkcg3lca6023sofhifom7</string></value></param><param><value><string>Troy</string></value></param></params></methodCall>
+
+'
+    headers:
+      User-Agent:
+      - XMLRPC::Client (Ruby 1.9.3)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '232'
+      Connection:
+      - keep-alive
+      Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Set-Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7; path=/
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '17279'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sat, 03 Nov 2012 13:58:58 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Cache-Backend:
+      - www
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<methodResponse>\n<params>\n
+        <param>\n  <value>\n   <struct>\n    <member>\n     <name>status</name>\n
+        \    <value>\n      <string>200 OK</string>\n     </value>\n    </member>\n
+        \   <member>\n     <name>data</name>\n     <value>\n      <array>\n       <data>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>0332452</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>Troy (2004) Photos (</string>\n           </value>\n          </member>\n
+        \        </struct>\n        </value>\n        <value>\n         <struct>\n
+        \         <member>\n           <name>id</name>\n           <value>\n            <string>1126490</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>Call Me Troy (2007)</string>\n           </value>\n
+        \         </member>\n         </struct>\n        </value>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>id</name>\n           <value>\n
+        \           <string>0431721</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>title</name>\n           <value>\n            <string>Denied
+        (2004) aka &#34;Troy Denied&#34; - Canada (English title) (working title)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>2287360</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>A Kid Called Troy (1993)</string>\n           </value>\n
+        \         </member>\n         </struct>\n        </value>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>id</name>\n           <value>\n
+        \           <string>0059262</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>title</name>\n           <value>\n            <string>Hercules
+        and the Princess of Troy (1965) (TV) aka &#34;Hercules vs. the Sea Monster&#34;
+        -</string>\n           </value>\n          </member>\n         </struct>\n
+        \       </value>\n        <value>\n         <struct>\n          <member>\n
+        \          <name>id</name>\n           <value>\n            <string>0768710</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>The Women of Troy (2006) (V)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>0484846</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>Helen of Troy (2005) (TV) aka &#34;I oraia Eleni&#34;
+        - Greece (transliterated ISO-LATIN-1 title)</string>\n           </value>\n
+        \         </member>\n         </struct>\n        </value>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>id</name>\n           <value>\n
+        \           <string>0422707</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>title</name>\n           <value>\n            <string>The
+        Making of 'Troy' (2004) (TV) aka &#34;N&#195;&#164;in tehtiin elokuva Troija&#34;
+        - Finland</string>\n           </value>\n          </member>\n         </struct>\n
+        \       </value>\n        <value>\n         <struct>\n          <member>\n
+        \          <name>id</name>\n           <value>\n            <string>0462049</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>The True Story of Troy (2004) (TV)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>0439021</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>Troy: From Ruins to Reality (2005) (V)</string>\n           </value>\n
+        \         </member>\n         </struct>\n        </value>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>id</name>\n           <value>\n
+        \           <string>0439022</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>title</name>\n           <value>\n            <string>Troy:
+        In the Thick of Battle (2005) (V)</string>\n           </value>\n          </member>\n
+        \        </struct>\n        </value>\n        <value>\n         <struct>\n
+        \         <member>\n           <name>id</name>\n           <value>\n            <string>0446541</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>Beyond the Movie: Troy (2004) (TV)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>0830492</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>&#34;The Troy Cory Evening Show&#34; (1974) (TV series)
+        aka &#34;The Troy Cory Show&#34; - USA (alternative title)</string>\n           </value>\n
+        \         </member>\n         </struct>\n        </value>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>id</name>\n           <value>\n
+        \           <string>0439020</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>title</name>\n           <value>\n            <string>Troy:
+        An Effects Odyssey (2004) (V)</string>\n           </value>\n          </member>\n
+        \        </struct>\n        </value>\n        <value>\n         <struct>\n
+        \         <member>\n           <name>id</name>\n           <value>\n            <string>0770821</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>Troy: The Passion of Helen (2004)
+        (TV)</string>\n           </value>\n          </member>\n         </struct>\n
+        \       </value>\n        <value>\n         <struct>\n          <member>\n
+        \          <name>id</name>\n           <value>\n            <string>0409399</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>Troy: The True Story of Love, Power,
+        Honor &#38; the Pursuit of Glory (2004) (V)</string>\n           </value>\n
+        \         </member>\n         </struct>\n        </value>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>id</name>\n           <value>\n
+        \           <string>1955057</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>title</name>\n           <value>\n            <string>Warriors:
+        Legends of Troy (2011) (VG)</string>\n           </value>\n          </member>\n
+        \        </struct>\n        </value>\n        <value>\n         <struct>\n
+        \         <member>\n           <name>id</name>\n           <value>\n            <string>2302499</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>A Life in the Balance: Examining the
+        Troy Davis Case (2011) (V)</string>\n           </value>\n          </member>\n
+        \        </struct>\n        </value>\n        <value>\n         <struct>\n
+        \         <member>\n           <name>id</name>\n           <value>\n            <string>1008665</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>Battle for Troy (2004) (VG)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>2148889</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>Chillerama Presents: Anton Troy, the Man Behind the Beast
+        (2011)</string>\n           </value>\n          </member>\n         </struct>\n
+        \       </value>\n        <value>\n         <struct>\n          <member>\n
+        \          <name>id</name>\n           <value>\n            <string>1575549</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>Forgiving Troy: The Documentary (2009)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>1918830</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>From Silence: Troy Donockley &#38; Dave Bainbridge (2006)
+        (TV)</string>\n           </value>\n          </member>\n         </struct>\n
+        \       </value>\n        <value>\n         <struct>\n          <member>\n
+        \          <name>id</name>\n           <value>\n            <string>0473990</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>Helene of Troy, N.Y. (1927)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>1315952</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>Helen of Troy (1917)</string>\n           </value>\n          </member>\n
+        \        </struct>\n        </value>\n        <value>\n         <struct>\n
+        \         <member>\n           <name>id</name>\n           <value>\n            <string>0014140</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>How Troy Was Collared (1923)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>0893352</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>Model Workout with Troy Warwell (2006) (V)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>2034066</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>North Troy Roughcut (2010)</string>\n           </value>\n
+        \         </member>\n         </struct>\n        </value>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>id</name>\n           <value>\n
+        \           <string>2336401</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>title</name>\n           <value>\n            <string>Odysseus:
+        The Jetman King of Ithaca's Journey to Troy (2012)</string>\n           </value>\n
+        \         </member>\n         </struct>\n        </value>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>id</name>\n           <value>\n
+        \           <string>1570652</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>title</name>\n           <value>\n            <string>O
+        kaimos tis Oraias Elenis - Polemos i erotas? (2005) aka &#34;The Yearning
+        of Troy Helen - War or Love?&#34; - International (English title)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>0044044</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>Sk&#195;&#182;na Helena (1951) aka &#34;Helen of Troy&#34;
+        - International (English title) aka &#34;Kaunis Helena&#34; - Finland</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>1829039</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>The Epic of Troy Knight (2015)</string>\n           </value>\n
+        \         </member>\n         </struct>\n        </value>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>id</name>\n           <value>\n
+        \           <string>1129385</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>title</name>\n           <value>\n            <string>The
+        Molders of Troy (1980) (TV)</string>\n           </value>\n          </member>\n
+        \        </struct>\n        </value>\n        <value>\n         <struct>\n
+        \         <member>\n           <name>id</name>\n           <value>\n            <string>1022880</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>The Night They Invented Troy Donahue
+        (2008)</string>\n           </value>\n          </member>\n         </struct>\n
+        \       </value>\n        <value>\n         <struct>\n          <member>\n
+        \          <name>id</name>\n           <value>\n            <string>0224296</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>The Trolley at East Troy (1986)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>2398664</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>&#34;The Troy Rawlings Show&#34; (2011) (TV series)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>1670355</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>The Troy Shawn Welcome Story (2010)</string>\n           </value>\n
+        \         </member>\n         </struct>\n        </value>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>id</name>\n           <value>\n
+        \           <string>2260927</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>title</name>\n           <value>\n            <string>&#34;Troy
+        Butcher vs. the World&#34; (2011) (TV series)</string>\n           </value>\n
+        \         </member>\n         </struct>\n        </value>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>id</name>\n           <value>\n
+        \           <string>2426976</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>title</name>\n           <value>\n            <string>Troy
+        Kallmann's: The Apartment (2012)</string>\n           </value>\n          </member>\n
+        \        </struct>\n        </value>\n        <value>\n         <struct>\n
+        \         <member>\n           <name>id</name>\n           <value>\n            <string>2266887</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>Troy: Naked Boys Behind Bars, Sing!
+        (2011)</string>\n           </value>\n          </member>\n         </struct>\n
+        \       </value>\n        <value>\n         <struct>\n          <member>\n
+        \          <name>id</name>\n           <value>\n            <string>2148676</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>title</name>\n
+        \          <value>\n            <string>Troy Speaks the Truth (2012)</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>id</name>\n
+        \          <value>\n            <string>2152728</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>title</name>\n           <value>\n
+        \           <string>Women of Troy (1958) (TV)</string>\n           </value>\n
+        \         </member>\n         </struct>\n        </value>\n        <value>\n
+        \        <struct>\n          <member>\n           <name>id</name>\n           <value>\n
+        \           <string>1996306680</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>title</name>\n           <value>\n            <string>Troy
+        - Myth Or Reality (2004)</string>\n           </value>\n          </member>\n
+        \        </struct>\n        </value>\n       </data>\n      </array>\n     </value>\n
+        \   </member>\n    <member>\n     <name>seconds</name>\n     <value>\n      <double>0.859</double>\n
+        \    </value>\n    </member>\n   </struct>\n  </value>\n </param>\n</params>\n</methodResponse>\n"
+    http_version: 
+  recorded_at: Sat, 03 Nov 2012 13:59:02 GMT
+recorded_with: VCR 2.3.0

--- a/spec/fixtures/http/search_subtitles_for_himym.yml
+++ b/spec/fixtures/http/search_subtitles_for_himym.yml
@@ -1,0 +1,424 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.opensubtitles.org/xml-rpc
+    body:
+      encoding: US-ASCII
+      string: ! '<?xml version="1.0" ?><methodCall><methodName>SearchSubtitles</methodName><params><param><value><string>0ij4vtkcg3lca6023sofhifom7</string></value></param><param><value><array><data><value><struct><member><name>moviehash</name><value><string>bd71526264fd8bd9</string></value></member><member><name>moviebytesize</name><value><string>183406990</string></value></member><member><name>sublanguageid</name><value><string>fre</string></value></member></struct></value></data></array></value></param></params></methodCall>
+
+'
+    headers:
+      User-Agent:
+      - XMLRPC::Client (Ruby 1.9.3)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '517'
+      Connection:
+      - keep-alive
+      Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Set-Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7; path=/
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '29213'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sat, 03 Nov 2012 13:58:55 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Cache-Backend:
+      - www
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<methodResponse>\n<params>\n
+        <param>\n  <value>\n   <struct>\n    <member>\n     <name>status</name>\n
+        \    <value>\n      <string>200 OK</string>\n     </value>\n    </member>\n
+        \   <member>\n     <name>data</name>\n     <value>\n      <array>\n       <data>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>moviehash</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>117533</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>bd71526264fd8bd9</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>183406990</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>1287000</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1951739419</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>How I Met Your Mother - 2x22 - Something
+        Blue.srt</string>\n           </value>\n          </member>\n          <member>\n
+        \          <name>SubActualCD</name>\n           <value>\n            <string>1</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>29532</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>49ba29341936f44b67f87abe58846e57</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>4361038</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>994714</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2008-01-31 17:15:39</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>10.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>1753</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>How I Met Your Mother - Season 2</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>90865</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>1017766</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>&#34;How I Met Your Mother&#34; Something
+        Blue</string>\n           </value>\n          </member>\n          <member>\n
+        \          <name>MovieNameEng</name>\n           <value>\n            <string/>\n
+        \          </value>\n          </member>\n          <member>\n           <name>MovieYear</name>\n
+        \          <value>\n            <string>2007</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieImdbRating</name>\n
+        \          <value>\n            <string>8.6</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFeatured</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserNickName</name>\n
+        \          <value>\n            <string>jlauwers</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>ISO639</name>\n
+        \          <value>\n            <string>fr</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>gold member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>2</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>22</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>episode</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>moviehash</name>\n
+        \             <value>\n               <string>bd71526264fd8bd9</string>\n
+        \             </value>\n             </member>\n             <member>\n              <name>moviebytesize</name>\n
+        \             <value>\n               <string>183406990</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1951739419.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/4361038</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/4361038/how-i-met-your-mother-something-blue-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>moviehash</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>872779</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>bd71526264fd8bd9</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>183406990</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1952337295</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>How I Met Your Mother S02E22 - Something
+        Blue.xor.VF.srt</string>\n           </value>\n          </member>\n          <member>\n
+        \          <name>SubActualCD</name>\n           <value>\n            <string>1</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>32467</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>981146aec08be3d6d8709641d782f5da</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>3687427</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>1253306</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2010-06-09 20:10:11</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>333</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string> How I Met Your Mother S02E22 - Something
+        Blue.xor.VF</string>\n           </value>\n          </member>\n          <member>\n
+        \          <name>IDMovie</name>\n           <value>\n            <string>90865</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>1017766</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>&#34;How I Met Your Mother&#34; Something
+        Blue</string>\n           </value>\n          </member>\n          <member>\n
+        \          <name>MovieNameEng</name>\n           <value>\n            <string/>\n
+        \          </value>\n          </member>\n          <member>\n           <name>MovieYear</name>\n
+        \          <value>\n            <string>2007</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieImdbRating</name>\n
+        \          <value>\n            <string>8.6</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFeatured</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserNickName</name>\n
+        \          <value>\n            <string>omarf1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>ISO639</name>\n
+        \          <value>\n            <string>fr</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>gold member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>2</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>22</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>episode</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>moviehash</name>\n
+        \             <value>\n               <string>bd71526264fd8bd9</string>\n
+        \             </value>\n             </member>\n             <member>\n              <name>moviebytesize</name>\n
+        \             <value>\n               <string>183406990</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1952337295.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/3687427</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/3687427/how-i-met-your-mother-something-blue-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>moviehash</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>1590113</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>bd71526264fd8bd9</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>183406990</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1952188857</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>How I Met Your Mother - 2x22 - Something
+        Blue.srt</string>\n           </value>\n          </member>\n          <member>\n
+        \          <name>SubActualCD</name>\n           <value>\n            <string>1</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>24762</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>9d51153ba5ec4b726ab5c6c983d4d93c</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>4328245</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>845334</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2009-09-14 20:03:22</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>480</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>How I Met Your Mother Season 2</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>90865</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>1017766</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>&#34;How I Met Your Mother&#34; Something
+        Blue</string>\n           </value>\n          </member>\n          <member>\n
+        \          <name>MovieNameEng</name>\n           <value>\n            <string/>\n
+        \          </value>\n          </member>\n          <member>\n           <name>MovieYear</name>\n
+        \          <value>\n            <string>2007</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieImdbRating</name>\n
+        \          <value>\n            <string>8.6</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFeatured</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserNickName</name>\n
+        \          <value>\n            <string>ZeRoCooL64</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>ISO639</name>\n
+        \          <value>\n            <string>fr</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>bronze member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>2</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>22</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>episode</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>moviehash</name>\n
+        \             <value>\n               <string>bd71526264fd8bd9</string>\n
+        \             </value>\n             </member>\n             <member>\n              <name>moviebytesize</name>\n
+        \             <value>\n               <string>183406990</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1952188857.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/4328245</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/4328245/how-i-met-your-mother-something-blue-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>moviehash</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>1945333</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>bd71526264fd8bd9</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>183406990</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1952693786</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>How I Met Your Mother - 2x22 - Something
+        Blue.fr.srt</string>\n           </value>\n          </member>\n          <member>\n
+        \          <name>SubActualCD</name>\n           <value>\n            <string>1</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>32684</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>1f0d06698c8b632edb89e0f72f36e7c1</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>4019688</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>1017601</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2010-12-23 12:26:24</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>148</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string> How I Met Your Mother - 2x22 - Something
+        Blue.fr</string>\n           </value>\n          </member>\n          <member>\n
+        \          <name>IDMovie</name>\n           <value>\n            <string>90865</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>1017766</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>&#34;How I Met Your Mother&#34; Something
+        Blue</string>\n           </value>\n          </member>\n          <member>\n
+        \          <name>MovieNameEng</name>\n           <value>\n            <string/>\n
+        \          </value>\n          </member>\n          <member>\n           <name>MovieYear</name>\n
+        \          <value>\n            <string>2007</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieImdbRating</name>\n
+        \          <value>\n            <string>8.6</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFeatured</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserNickName</name>\n
+        \          <value>\n            <string>hrxfab</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>ISO639</name>\n
+        \          <value>\n            <string>fr</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>gold member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>2</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>22</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>episode</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>moviehash</name>\n
+        \             <value>\n               <string>bd71526264fd8bd9</string>\n
+        \             </value>\n             </member>\n             <member>\n              <name>moviebytesize</name>\n
+        \             <value>\n               <string>183406990</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1952693786.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/4019688</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/4019688/how-i-met-your-mother-something-blue-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \      </data>\n      </array>\n     </value>\n    </member>\n    <member>\n
+        \    <name>seconds</name>\n     <value>\n      <double>0.011</double>\n     </value>\n
+        \   </member>\n   </struct>\n  </value>\n </param>\n</params>\n</methodResponse>\n"
+    http_version: 
+  recorded_at: Sat, 03 Nov 2012 13:58:59 GMT
+recorded_with: VCR 2.3.0

--- a/spec/fixtures/http/search_subtitles_for_the_rock.yml
+++ b/spec/fixtures/http/search_subtitles_for_the_rock.yml
@@ -1,0 +1,1373 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.opensubtitles.org/xml-rpc
+    body:
+      encoding: US-ASCII
+      string: ! '<?xml version="1.0" ?><methodCall><methodName>SearchSubtitles</methodName><params><param><value><string>0ij4vtkcg3lca6023sofhifom7</string></value></param><param><value><array><data><value><struct><member><name>imdbid</name><value><string>0117500</string></value></member><member><name>sublanguageid</name><value><string>fre</string></value></member></struct></value></data></array></value></param></params></methodCall>
+
+'
+    headers:
+      User-Agent:
+      - XMLRPC::Client (Ruby 1.9.3)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '421'
+      Connection:
+      - keep-alive
+      Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Set-Cookie:
+      - PHPSESSID=0ij4vtkcg3lca6023sofhifom7; path=/
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '103156'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sat, 03 Nov 2012 13:58:56 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Cache-Backend:
+      - www
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<methodResponse>\n<params>\n
+        <param>\n  <value>\n   <struct>\n    <member>\n     <name>status</name>\n
+        \    <value>\n      <string>200 OK</string>\n     </value>\n    </member>\n
+        \   <member>\n     <name>data</name>\n     <value>\n      <array>\n       <data>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>130869</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>The.Rock.1996.DVDRip-XviD-AC3-HigHoT.CD1.srt</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>53378</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>d8d748ed935bda62b9b80847ba5cc92a</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>96357</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>45344</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>2</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2005-05-24 00:00:00</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>220</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>Rock, The (1996)</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string>_brucelee_ (a)</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>bronze member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>movie</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/130869.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/96357</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/96357/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>130870</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>The.Rock.1996.DVDRip-XviD-AC3-HigHoT.CD2.srt</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>2</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>41347</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>a4df833343915611ccfa87e676672ee6</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>96357</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>45344</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>2</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2005-05-24 00:00:00</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>220</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>Rock, The (1996)</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string>_brucelee_ (a)</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>bronze member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>movie</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/130870.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/96357</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/96357/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>164082</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>rock-1cd.srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>90541</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>d87286f6ee6dd80fbc8297aabf5a9963</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>120493</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>780004</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2005-03-01 00:00:00</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>397</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string>fabhawk</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>gold member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>movie</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/164082.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/120493</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/120493/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>189526</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>The_Rock_fr.sub</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>84125</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>aae70e25befbdc3e076c8b929e0e3a56</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>138327</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>58726</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>txt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2001-09-05 00:00:00</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>373</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string>likwid (a)</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>bronze member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>movie</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/189526.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/138327</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/138327/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>211266</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>Rock.sub</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>68462</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>9de5b205a7418964c394a91420699417</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>155044</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>37141</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>sub</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string>The rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAddDate</name>\n
+        \          <value>\n            <string>2005-03-01 00:00:00</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubBad</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>250</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string> Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string>mlapacek (a)</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>platinum member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>movie</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/211266.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/155044</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/155044/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>259565</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>[35816] Rock, The (1996).srt</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>95095</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>37897472c795d697c37b0fd50f84940b</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>195910</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>63243</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2004-03-05 00:00:00</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>523</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>Rock, The (1996)</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string>BetaMAN (a)</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>platinum member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>movie</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/259565.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/195910</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/195910/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1951908937</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>The Rock.srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>96277</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>65ce3de7357261f1cdb9ccd5ed479b84</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>3315479</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2008-08-16 01:41:29</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>1248</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>IDMovie</name>\n           <value>\n
+        \           <string>1589</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>IDMovieImdb</name>\n           <value>\n
+        \           <string>117500</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieName</name>\n           <value>\n
+        \           <string>The Rock</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieNameEng</name>\n           <value>\n
+        \           <string/>\n           </value>\n          </member>\n          <member>\n
+        \          <name>MovieYear</name>\n           <value>\n            <string>1996</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>MovieImdbRating</name>\n
+        \          <value>\n            <string>7.3</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFeatured</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserNickName</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesSeason</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesEpisode</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieKind</name>\n           <value>\n
+        \           <string>movie</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryParameters</name>\n           <value>\n
+        \           <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1951908937.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/3315479</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/3315479/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1951918400</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>The.Rock[1996]DvDrip[Eng]-Chopper.srt</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>95964</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>dbeca313148d5e79eecfe58c4d3c2adf</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>3324276</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string>Sous titres ajust&#195;&#169; par
+        moi.&#13;&#10;Pour la version &#34;Chopper&#34;</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAddDate</name>\n
+        \          <value>\n            <string>2008-08-25 22:36:21</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubBad</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>334</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>The.Rock[1996]DvDrip[Eng]-Chopper.srt</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string/>\n           </value>\n          </member>\n          <member>\n
+        \          <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesSeason</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesEpisode</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieKind</name>\n           <value>\n
+        \           <string>movie</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryParameters</name>\n           <value>\n
+        \           <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1951918400.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/3324276</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/3324276/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1951955850</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>The Rock[1996]DVDRip[Eng]-NuMy.FR.srt</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>96182</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>503b5ee32dda104dbe5f0ff13dd822ae</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>3355464</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>655057</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string>The Rock[1996]DVDRip[Eng]-NuMy</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubAddDate</name>\n
+        \          <value>\n            <string>2008-10-21 00:08:03</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubBad</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>10.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>571</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>The Rock[1996]DVDRip[Eng]-NuMy</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string/>\n           </value>\n          </member>\n          <member>\n
+        \          <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesSeason</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesEpisode</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieKind</name>\n           <value>\n
+        \           <string>movie</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryParameters</name>\n           <value>\n
+        \           <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1951955850.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/3355464</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/3355464/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1951956275</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>The.Rock[1996]DvDrip[Eng]-Chopper.FR.srt</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>96182</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>949fed94361dcb4983cb2567a407257a</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>3355850</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>655057</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string>The Rock[1996]DvDrip[Eng]-Chopper</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubAddDate</name>\n
+        \          <value>\n            <string>2008-10-21 17:44:21</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubBad</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>867</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>The Rock[1996]DvDrip[Eng]-Chopper</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string/>\n           </value>\n          </member>\n          <member>\n
+        \          <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesSeason</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesEpisode</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieKind</name>\n           <value>\n
+        \           <string>movie</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryParameters</name>\n           <value>\n
+        \           <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1951956275.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/3355850</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/3355850/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1952185402</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>The.Rock.1996.720p.BluRay.DTS.x264-ESiR.srt</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>95789</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>ff9db007ef35c9bf5ccc2b812454562f</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>3558820</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>1029775</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2009-09-09 05:15:58</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>766</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>The.Rock.1996.720p.BluRay.DTS.x264-ESiR</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string>XeiS</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>silver member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>movie</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1952185402.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/3558820</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/3558820/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1952300954</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>The.Rock.1996.CE.iNTERNAL.DVDRiP.XviD.AC3.CD1-HLS.srt</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>55417</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>e66518cc969f378714474336d7bec7a8</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>3657366</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>399563</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>2</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2010-03-24 18:43:02</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>227</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>The.Rock.1996.CE.iNTERNAL.DVDRiP.XviD.AC3-HLS</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string>darko_xx</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>gold member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>movie</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1952300954.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/3657366</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/3657366/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1952300955</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>The.Rock.1996.CE.iNTERNAL.DVDRiP.XviD.AC3.CD2-HLS.srt</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>2</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>40269</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>e97d079103811b48e9decc3101ae851e</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>3657366</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>399563</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>2</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2010-03-24 18:43:02</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>227</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>The.Rock.1996.CE.iNTERNAL.DVDRiP.XviD.AC3-HLS</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string>darko_xx</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string>gold member</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesSeason</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SeriesEpisode</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieKind</name>\n
+        \          <value>\n            <string>movie</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>QueryParameters</name>\n
+        \          <value>\n            <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1952300955.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/3657366</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/3657366/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1952859747</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>The.Rock.srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>96941</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>89bbe2b3ff8e3d0885eddd70c8e49554</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>4178414</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2011-05-15 22:34:13</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>307</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string/>\n           </value>\n          </member>\n          <member>\n
+        \          <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesSeason</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesEpisode</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieKind</name>\n           <value>\n
+        \           <string>movie</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryParameters</name>\n           <value>\n
+        \           <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1952859747.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/4178414</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/4178414/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \       <value>\n         <struct>\n          <member>\n           <name>MatchedBy</name>\n
+        \          <value>\n            <string>imdbid</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubMovieFile</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieHash</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieByteSize</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieTimeMS</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDSubtitleFile</name>\n
+        \          <value>\n            <string>1953171434</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFileName</name>\n
+        \          <value>\n            <string>Rock.1996.TRUEFRENCH.SUBFORCED.BRRiP.XViD.AC3-HuSh.srt</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubActualCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSize</name>\n
+        \          <value>\n            <string>1323</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHash</name>\n
+        \          <value>\n            <string>07af4ac82580cb3418767125f2a17389</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDSubtitle</name>\n
+        \          <value>\n            <string>4623609</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserID</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubLanguageID</name>\n
+        \          <value>\n            <string>fre</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubFormat</name>\n
+        \          <value>\n            <string>srt</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubSumCD</name>\n
+        \          <value>\n            <string>1</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubAuthorComment</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubAddDate</name>\n           <value>\n
+        \           <string>2012-07-23 05:57:06</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubBad</name>\n           <value>\n            <string>0</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubRating</name>\n
+        \          <value>\n            <string>0.0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubDownloadsCnt</name>\n
+        \          <value>\n            <string>91</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieReleaseName</name>\n
+        \          <value>\n            <string>Rock.1996.TRUEFRENCH.SUBFORCED.BRRiP.XViD.AC3-HuSh</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>IDMovie</name>\n
+        \          <value>\n            <string>1589</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>IDMovieImdb</name>\n
+        \          <value>\n            <string>117500</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieName</name>\n
+        \          <value>\n            <string>The Rock</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>MovieNameEng</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieYear</name>\n           <value>\n
+        \           <string>1996</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieImdbRating</name>\n           <value>\n
+        \           <string>7.3</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubFeatured</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>UserNickName</name>\n           <value>\n
+        \           <string/>\n           </value>\n          </member>\n          <member>\n
+        \          <name>ISO639</name>\n           <value>\n            <string>fr</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>LanguageName</name>\n
+        \          <value>\n            <string>French</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubComments</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>SubHearingImpaired</name>\n
+        \          <value>\n            <string>0</string>\n           </value>\n
+        \         </member>\n          <member>\n           <name>UserRank</name>\n
+        \          <value>\n            <string/>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesSeason</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SeriesEpisode</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>MovieKind</name>\n           <value>\n
+        \           <string>movie</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryParameters</name>\n           <value>\n
+        \           <struct>\n             <member>\n              <name>imdbid</name>\n
+        \             <value>\n               <string>0117500</string>\n              </value>\n
+        \            </member>\n             <member>\n              <name>sublanguageid</name>\n
+        \             <value>\n               <string>fre</string>\n              </value>\n
+        \            </member>\n            </struct>\n           </value>\n          </member>\n
+        \         <member>\n           <name>QueryNumber</name>\n           <value>\n
+        \           <string>0</string>\n           </value>\n          </member>\n
+        \         <member>\n           <name>SubDownloadLink</name>\n           <value>\n
+        \           <string>http://dl.opensubtitles.org/en/download/filead/1953171434.gz</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>ZipDownloadLink</name>\n
+        \          <value>\n            <string>http://dl.opensubtitles.org/en/download/subad/4623609</string>\n
+        \          </value>\n          </member>\n          <member>\n           <name>SubtitlesLink</name>\n
+        \          <value>\n            <string>http://www.opensubtitles.org/en/subtitles/4623609/the-rock-fr</string>\n
+        \          </value>\n          </member>\n         </struct>\n        </value>\n
+        \      </data>\n      </array>\n     </value>\n    </member>\n    <member>\n
+        \    <name>seconds</name>\n     <value>\n      <double>0.012</double>\n     </value>\n
+        \   </member>\n   </struct>\n  </value>\n </param>\n</params>\n</methodResponse>\n"
+    http_version: 
+  recorded_at: Sat, 03 Nov 2012 13:59:00 GMT
+recorded_with: VCR 2.3.0

--- a/spec/fixtures/http/server_info.yml
+++ b/spec/fixtures/http/server_info.yml
@@ -1,0 +1,166 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.opensubtitles.org/xml-rpc
+    body:
+      encoding: US-ASCII
+      string: ! '<?xml version="1.0" ?><methodCall><methodName>ServerInfo</methodName><params/></methodCall>
+
+'
+    headers:
+      User-Agent:
+      - XMLRPC::Client (Ruby 1.9.3)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '92'
+      Connection:
+      - keep-alive
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '9662'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sat, 03 Nov 2012 13:58:53 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Cache-Backend:
+      - www
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<methodResponse>\n<params>\n
+        <param>\n  <value>\n   <struct>\n    <member>\n     <name>xmlrpc_version</name>\n
+        \    <value>\n      <string>0.1</string>\n     </value>\n    </member>\n    <member>\n
+        \    <name>xmlrpc_url</name>\n     <value>\n      <string>http://api.opensubtitles.org/xml-rpc</string>\n
+        \    </value>\n    </member>\n    <member>\n     <name>application</name>\n
+        \    <value>\n      <string>OpenSuber v0.2</string>\n     </value>\n    </member>\n
+        \   <member>\n     <name>contact</name>\n     <value>\n      <string>admin@opensubtitles.org</string>\n
+        \    </value>\n    </member>\n    <member>\n     <name>website_url</name>\n
+        \    <value>\n      <string>http://www.opensubtitles.org</string>\n     </value>\n
+        \   </member>\n    <member>\n     <name>users_online_total</name>\n     <value>\n
+        \     <int>10015</int>\n     </value>\n    </member>\n    <member>\n     <name>users_online_program</name>\n
+        \    <value>\n      <int>7403</int>\n     </value>\n    </member>\n    <member>\n
+        \    <name>users_loggedin</name>\n     <value>\n      <int>84</int>\n     </value>\n
+        \   </member>\n    <member>\n     <name>users_max_alltime</name>\n     <value>\n
+        \     <string>27449</string>\n     </value>\n    </member>\n    <member>\n
+        \    <name>users_registered</name>\n     <value>\n      <string>1025038</string>\n
+        \    </value>\n    </member>\n    <member>\n     <name>subs_downloads</name>\n
+        \    <value>\n      <string>765234933</string>\n     </value>\n    </member>\n
+        \   <member>\n     <name>subs_subtitle_files</name>\n     <value>\n      <string>1863523</string>\n
+        \    </value>\n    </member>\n    <member>\n     <name>movies_total</name>\n
+        \    <value>\n      <string>136399</string>\n     </value>\n    </member>\n
+        \   <member>\n     <name>movies_aka</name>\n     <value>\n      <string>277538</string>\n
+        \    </value>\n    </member>\n    <member>\n     <name>total_subtitles_languages</name>\n
+        \    <value>\n      <string>61</string>\n     </value>\n    </member>\n    <member>\n
+        \    <name>last_update_strings</name>\n     <value>\n      <struct>\n       <member>\n
+        \       <name>ar</name>\n        <value>\n         <string>2007-02-03 21:36:14</string>\n
+        \       </value>\n       </member>\n       <member>\n        <name>bg</name>\n
+        \       <value>\n         <string>2007-02-03 21:36:14</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>ca</name>\n        <value>\n
+        \        <string>2009-07-06 06:20:41</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>cs</name>\n        <value>\n         <string>2007-02-03
+        21:36:15</string>\n        </value>\n       </member>\n       <member>\n        <name>da</name>\n
+        \       <value>\n         <string>2007-02-16 14:07:42</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>de</name>\n        <value>\n
+        \        <string>2007-02-03 21:36:15</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>el</name>\n        <value>\n         <string>2007-02-03
+        21:36:17</string>\n        </value>\n       </member>\n       <member>\n        <name>en</name>\n
+        \       <value>\n         <string>2007-02-03 21:36:14</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>es</name>\n        <value>\n
+        \        <string>2007-02-03 21:36:21</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>et</name>\n        <value>\n         <string>2007-05-07
+        20:43:40</string>\n        </value>\n       </member>\n       <member>\n        <name>eu</name>\n
+        \       <value>\n         <string>2011-08-28 08:37:00</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>fa</name>\n        <value>\n
+        \        <string>2007-02-03 21:36:16</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>fi</name>\n        <value>\n         <string>2007-02-03
+        21:36:16</string>\n        </value>\n       </member>\n       <member>\n        <name>fr</name>\n
+        \       <value>\n         <string>2007-02-03 21:36:16</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>gl</name>\n        <value>\n
+        \        <string>2007-10-11 16:23:40</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>he</name>\n        <value>\n         <string>2007-02-03
+        21:36:17</string>\n        </value>\n       </member>\n       <member>\n        <name>hi</name>\n
+        \       <value>\n         <string>2011-11-07 09:54:58</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>hr</name>\n        <value>\n
+        \        <string>2007-02-04 11:05:51</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>hu</name>\n        <value>\n         <string>2007-02-03
+        21:36:17</string>\n        </value>\n       </member>\n       <member>\n        <name>id</name>\n
+        \       <value>\n         <string>2007-02-03 21:36:18</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>is</name>\n        <value>\n
+        \        <string>2011-01-04 20:33:08</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>it</name>\n        <value>\n         <string>2007-02-03
+        21:36:18</string>\n        </value>\n       </member>\n       <member>\n        <name>ja</name>\n
+        \       <value>\n         <string>2007-02-04 11:05:11</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>ka</name>\n        <value>\n
+        \        <string>2007-06-09 17:08:29</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>km</name>\n        <value>\n         <string>2011-12-31
+        03:57:52</string>\n        </value>\n       </member>\n       <member>\n        <name>ko</name>\n
+        \       <value>\n         <string>2007-02-04 11:05:16</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>mk</name>\n        <value>\n
+        \        <string>2007-12-06 10:45:07</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>ms</name>\n        <value>\n         <string>2009-04-18
+        09:08:07</string>\n        </value>\n       </member>\n       <member>\n        <name>nl</name>\n
+        \       <value>\n         <string>2007-02-03 21:36:15</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>no</name>\n        <value>\n
+        \        <string>2007-02-03 21:36:18</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>oc</name>\n        <value>\n         <string>2008-12-16
+        12:56:29</string>\n        </value>\n       </member>\n       <member>\n        <name>pb</name>\n
+        \       <value>\n         <string>2007-02-03 21:36:19</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>pl</name>\n        <value>\n
+        \        <string>2007-02-03 21:36:19</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>pt</name>\n        <value>\n         <string>2007-02-03
+        21:36:19</string>\n        </value>\n       </member>\n       <member>\n        <name>ro</name>\n
+        \       <value>\n         <string>2007-02-03 21:36:20</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>ru</name>\n        <value>\n
+        \        <string>2007-02-03 21:36:20</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>si</name>\n        <value>\n         <string>2009-08-09
+        10:06:20</string>\n        </value>\n       </member>\n       <member>\n        <name>sk</name>\n
+        \       <value>\n         <string>2007-02-03 21:36:20</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>sl</name>\n        <value>\n
+        \        <string>2008-08-26 08:39:30</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>sq</name>\n        <value>\n         <string>2008-03-06
+        19:11:57</string>\n        </value>\n       </member>\n       <member>\n        <name>sr</name>\n
+        \       <value>\n         <string>2007-09-05 10:16:25</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>sv</name>\n        <value>\n
+        \        <string>2007-02-03 21:36:21</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>th</name>\n        <value>\n         <string>2007-06-28
+        10:37:46</string>\n        </value>\n       </member>\n       <member>\n        <name>tl</name>\n
+        \       <value>\n         <string>2009-08-24 16:32:10</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>tr</name>\n        <value>\n
+        \        <string>2007-02-03 21:36:22</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>uk</name>\n        <value>\n         <string>2010-03-22
+        10:14:26</string>\n        </value>\n       </member>\n       <member>\n        <name>vi</name>\n
+        \       <value>\n         <string>2007-02-04 11:05:03</string>\n        </value>\n
+        \      </member>\n       <member>\n        <name>zh</name>\n        <value>\n
+        \        <string>2007-02-04 11:05:27</string>\n        </value>\n       </member>\n
+        \     </struct>\n     </value>\n    </member>\n    <member>\n     <name>download_limits</name>\n
+        \    <value>\n      <struct>\n       <member>\n        <name>global_24h_download_limit</name>\n
+        \       <value>\n         <int>200</int>\n        </value>\n       </member>\n
+        \      <member>\n        <name>client_ip</name>\n        <value>\n         <string>80.30.33.21</string>\n
+        \       </value>\n       </member>\n       <member>\n        <name>limit_check_by</name>\n
+        \       <value>\n         <string>user_ip</string>\n        </value>\n       </member>\n
+        \      <member>\n        <name>client_24h_download_count</name>\n        <value>\n
+        \        <int>0</int>\n        </value>\n       </member>\n       <member>\n
+        \       <name>client_download_quota</name>\n        <value>\n         <int>200</int>\n
+        \       </value>\n       </member>\n       <member>\n        <name>client_24h_download_limit</name>\n
+        \       <value>\n         <int>200</int>\n        </value>\n       </member>\n
+        \     </struct>\n     </value>\n    </member>\n    <member>\n     <name>seconds</name>\n
+        \    <value>\n      <double>0.006</double>\n     </value>\n    </member>\n
+        \  </struct>\n  </value>\n </param>\n</params>\n</methodResponse>\n"
+    http_version: 
+  recorded_at: Sat, 03 Nov 2012 13:58:56 GMT
+recorded_with: VCR 2.3.0

--- a/spec/osdb/server_spec.rb
+++ b/spec/osdb/server_spec.rb
@@ -24,40 +24,51 @@ describe OSDb::Server do
   end
 
   it 'should respond to #info' do
-    info = subject.info
-    expected_info.each do |key, value|
-      info[key].should == value
+    VCR.use_cassette('server_info') do
+      info = subject.info
+      expected_info.each do |key, value|
+        info[key].should == value
+      end
+      info['seconds'].should be_a(Float)
+      info['last_update_strings'].should be_a(Hash)
     end
-    info['seconds'].should be_a(Float)
-    info['last_update_strings'].should be_a(Hash)
   end
 
   it 'should automatically call #login when token is needed' do
-    subject.instance_variable_get('@token').should be_nil
-    subject.token.should match(/[a-z0-9]{26}/)
-    subject.instance_variable_get('@token').should == subject.token
+    VCR.use_cassette('log_in') do
+      subject.instance_variable_get('@token').should be_nil
+      subject.token.should match(/[a-z0-9]{26}/)
+      subject.instance_variable_get('@token').should == subject.token
+    end
   end
 
   it 'should clear @login after #logout' do
-    expect{
-      subject.logout
-    }.to change{ subject.instance_variable_get('@token') }.from(instance_of(String)).to(nil)
+    VCR.use_cassette('log_in') do
+      subject.token
+    end
+    VCR.use_cassette('log_out') do
+      expect {
+        subject.logout
+      }.to change{ subject.instance_variable_get('@token') }.from(instance_of(String)).to(nil)
+    end
   end
 
   describe "#check_movie_hash" do
 
     it 'should identify movie' do
-      subject.check_movie_hash('37d0c7d0cfcbe280')['data'].should == {
-        "37d0c7d0cfcbe280" => {
-          "MovieYear" => "1996",
-          "MovieImdbID" => "0117500",
-          "MovieName" => "The Rock",
-          "MovieHash" => "37d0c7d0cfcbe280",
-          "MovieKind" => "movie",
-          "SeriesSeason" => "0",
-          "SeriesEpisode" => "0"
+      VCR.use_cassette('check_movie_hash') do
+        subject.check_movie_hash('37d0c7d0cfcbe280')['data'].should == {
+          "37d0c7d0cfcbe280" => {
+            "MovieYear" => "1996",
+            "MovieImdbID" => "0117500",
+            "MovieName" => "The Rock",
+            "MovieHash" => "37d0c7d0cfcbe280",
+            "MovieKind" => "movie",
+            "SeriesSeason" => "0",
+            "SeriesEpisode" => "0"
+          }
         }
-      }
+      end
     end
 
   end
@@ -65,22 +76,26 @@ describe OSDb::Server do
   describe '#search_subtitles' do
 
     it 'can search by hash and size' do
-      subs = subject.search_subtitles(:moviehash => 'bd71526264fd8bd9', :moviebytesize => '183406990', :sublanguageid => 'fre')
-      subs.should be_a(Array)
-      subs.length.should >= 2
-      subs.each do |sub|
-        sub.language.name.should == 'French'
-        sub.raw_data['MovieName'].should =~ /How I Met Your Mother/
+      VCR.use_cassette('search_subtitles_for_himym') do
+        subs = subject.search_subtitles(:moviehash => 'bd71526264fd8bd9', :moviebytesize => '183406990', :sublanguageid => 'fre')
+        subs.should be_a(Array)
+        subs.length.should >= 2
+        subs.each do |sub|
+          sub.language.name.should == 'French'
+          sub.raw_data['MovieName'].should =~ /How I Met Your Mother/
+        end
       end
     end
 
     it 'can search by imdbid' do
-      subs = subject.search_subtitles(:imdbid => "0117500", :sublanguageid => 'fre')
-      subs.should be_a(Array)
-      subs.length.should >= 1
-      subs.each do |sub|
-        sub.language.name.should == 'French'
-        sub.raw_data['MovieName'].should == 'The Rock'
+      VCR.use_cassette('search_subtitles_for_the_rock') do
+        subs = subject.search_subtitles(:imdbid => "0117500", :sublanguageid => 'fre')
+        subs.should be_a(Array)
+        subs.length.should >= 1
+        subs.each do |sub|
+          sub.language.name.should == 'French'
+          sub.raw_data['MovieName'].should == 'The Rock'
+        end
       end
     end
 
@@ -88,16 +103,20 @@ describe OSDb::Server do
 
   describe "#search_imdb" do
     it "can search imdb by title" do
-      imdb = subject.search_imdb(:query => "Troy")
-      imdb.each do |movie|
-        movie.title.should =~ /Troy/
+      VCR.use_cassette('search_imdb') do
+        imdb = subject.search_imdb(:query => "Troy")
+        imdb.each do |movie|
+          movie.title.should =~ /Troy/
+        end
       end
     end
 
     it "can get the details of a movie from an id" do
-      movie = subject.get_imdb_movie_details('0176415')
-      movie.title.should == 'El abuelo'
-      movie.year.should == 1998
+      VCR.use_cassette('get_imdb_movie_details') do
+        movie = subject.get_imdb_movie_details('0176415')
+        movie.title.should == 'El abuelo'
+        movie.year.should == 1998
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,14 @@
 require File.dirname(__FILE__) + '/../lib/osdb'
 require 'rspec'
 
+require 'webmock/rspec'
+require 'vcr'
+
 RSpec.configure do |c|
   c.mock_with :rspec
+end
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/fixtures/http'
+  c.hook_into :webmock
 end


### PR DESCRIPTION
A couple days ago the tests were failing for me because I was not connected to any network, and so realized that requests to opensubtitles.org were being done in the server specs.

I have included [VCR](https://github.com/myronmarston/vcr) and [WebMock](https://github.com/bblimke/webmock) in the gem specification and modified the server specs to use them. Now, there is no dependency with the OS server (which is also slow and sometimes fails for no apparent reason).

Also, tests now run much more faster, see below:
##### Original

```
% rspec spec
............................

Finished in 31.42 seconds
28 examples, 0 failures
```
##### Using VCR

```
% rspec spec
............................

Finished in 0.22798 seconds
28 examples, 0 failures
```
