### PR TITLE
In case of environment variable LANG was not defined (for example

### DIFF
--- a/bin/getsub
+++ b/bin/getsub
@@ -43,7 +43,15 @@ class GetSub
   end
 
   def env_lang
+<<<<<<< HEAD
     OSDb::Language.from_locale(ENV['LANG'] || "en_US.UTF-8")
+=======
+    lang = ENV['LANG']
+    if lang.nil?  
+      lang = "en_US.UTF-8"
+    end
+    OSDb::Language.from_locale(lang)
+>>>>>>> 22805a471e0b066fe95d5459f8f992840d473163
   end
 
   def run!(files)


### PR DESCRIPTION
when running on Mac OS X 10.9.1) the execution fails. This patch
sets the default language to eng in case of LANG is not set.
